### PR TITLE
Use .jshintrc if available

### DIFF
--- a/getConfig.js
+++ b/getConfig.js
@@ -1,0 +1,49 @@
+//
+// Locate the appropriate .jshintrc to use when running JSHint.
+//
+// Borrows search logic from: http://github.com/jshint/node-jshint/
+//
+
+var path = require('path'),
+    fs = require('fs');
+
+function removeJsComments(str) {
+    str = str || '';
+    str = str.replace(/\/\*(?:(?!\*\/)[\s\S])*\*\//g, '');
+    str = str.replace(/\/\/[^\n\r]*/g, ''); //everything after "//"
+    return str;
+}
+
+function findNearestConfig(fileName, dirName) {
+    dirName = dirName || process.cwd();
+
+    var targetFileName = path.normalize(path.join(dirName, fileName));
+    if (fs.existsSync(targetFileName)) {
+        return targetFileName;
+    }
+
+    var parentDirName = path.resolve(dirName, '..');
+    if (dirName === parentDirName) {
+        return null;
+    } else {
+        return findNearestConfig(fileName, parentDirName);
+    }
+}
+
+function getConfig(startingDir) {
+    var projectConfigPath = findNearestConfig('.jshintrc', startingDir),
+        homeConfigPath = path.normalize(path.join(process.env.HOME,
+            '.jshintrc'));
+    if (!fs.existsSync(homeConfigPath)) { homeConfigPath = null; }
+
+    var configPath = projectConfigPath || homeConfigPath;
+
+    if (configPath) {
+         return JSON.parse(removeJsComments(fs.readFileSync(configPath,
+             'utf-8')));
+    } else {
+        return {};
+    }
+}
+
+module.exports = getConfig;

--- a/init.js
+++ b/init.js
@@ -1,4 +1,6 @@
-var jshint = require('jshint');
+var jshint = require('jshint'),
+    path = require('path'),
+    getConfig = require('./getConfig.js');
 
 function buildTitle(documentName, errorCount) {
   return errorCount + ' errors in ' + documentName;

--- a/init.js
+++ b/init.js
@@ -9,7 +9,11 @@ var window;
 Hooks.addMenuItem("Actions/JavaScript/JSHint document", "cmd-ctrl-h", function () {
     
     var doc = Document.current(),
-        result = jshint.JSHINT(doc.text);
+        docPath = doc.path(),
+        configDir = docPath ? path.dirname(docPath) : process.env.HOME;
+        
+    var config = getConfig(configDir),
+        result = jshint.JSHINT(doc.text, config);
     
     // Only show the window if we have errors.
     if (!result) {


### PR DESCRIPTION
Use the user’s defined `.jshintrc` options when running JSHint.

The logic comes from the [node-jshint CLI utility](https://github.com/jshint/node-jshint/blob/master/lib/cli.js):
1. First, locate any project-specific `.jshintrc`, searching up the dir tree until we find it or get to the root directory.
2. If not found, try `$HOME/.jshintrc`.
3. If that isn’t found, use the default options.
