### PR TITLE
Display the results in a sheet instead of a window.

### DIFF
--- a/init.js
+++ b/init.js
@@ -4,8 +4,6 @@ function buildTitle(documentName, errorCount) {
   return errorCount + ' errors in ' + documentName;
 }
 
-var window;
-
 Hooks.addMenuItem("Actions/JavaScript/JSHint document", "cmd-ctrl-h", function () {
     
     var doc = Document.current(),
@@ -16,26 +14,25 @@ Hooks.addMenuItem("Actions/JavaScript/JSHint document", "cmd-ctrl-h", function (
       var data = jshint.JSHINT.data();
       var errors = data.errors;
       
-      if (typeof window === 'undefined') {
-        window = new Window();
-        window.htmlPath = 'index.html';
-        window.buttons = ["OK"];
-        window.onButtonClick = function() { window.close(); }
-        window.size = {width: 250, height: 300};
-        
-        window.onMessage = function (name, arguments) {
-          if (name === 'goToLine') {
-            var lineNum = arguments[0];
-            
-            Recipe.run(function (recipe) {
-              // Line number is 0 indexed in chocolat.
-              // Don't need to verify if lineNum is 0 since it should never be.
-              var range = recipe.characterRangeForLineIndexes(new Range(lineNum - 1,0));
-              recipe.selection = range;
-            });
-          }
-        };
-      }
+      var window = new Sheet(MainWindow.current());
+      window.htmlPath = 'index.html';
+      window.buttons = ["OK"];
+      window.onButtonClick = function() { window.close(); }
+      window.size = {width: 250, height: 300};
+      
+      window.onMessage = function (name, arguments) {
+        if (name === 'goToLine') {
+          var lineNum = arguments[0];
+          
+          Recipe.run(function (recipe) {
+            // Line number is 0 indexed in chocolat.
+            // Don't need to verify if lineNum is 0 since it should never be.
+            var range = recipe.characterRangeForLineIndexes(new Range(lineNum - 1,0));
+            recipe.selection = range;
+            window.close();
+          });
+        }
+      };
       
       window.title = buildTitle(doc.filename(), errors.length);
       window.run();


### PR DESCRIPTION
Currently the results are displayed in a window, which is nice, except for the following problem: the window stops working if you close it using the OK button, and will eventually also stop working if you close it using the red “X” button.

The OK button problem is fixable, but as far as I can tell, there is no reliable way to fix the red “X” problem at this time. See https://github.com/fileability/chocolat-public/issues/1171.

Using a sheet fixes these problems. It is not as good as a separate window would be, but is the next best thing.
