### PR TITLE
Workflow improvements, window stability

### DIFF
--- a/init.js
+++ b/init.js
@@ -2,36 +2,111 @@ var jshint = require('jshint'),
     path = require('path'),
     getConfig = require('./getConfig.js');
 
-function buildTitle(documentName, errorCount) {
-  return errorCount + ' errors in ' + documentName;
-}
-
 var window;
 
-Hooks.addMenuItem("Actions/JavaScript/JSHint document", "cmd-ctrl-h", function () {
-    
+function run() {
+  
+  if (Document.current()) {
     var doc = Document.current(),
         docPath = doc.path(),
+        scope = doc.rootScope(),
         configDir = docPath ? path.dirname(docPath) : process.env.HOME;
         
     var config = getConfig(configDir),
         result = jshint.JSHINT(doc.text, config);
+   
     
-    // Only show the window if we have errors.
-    if (!result) {
+    var refreshWindow = function() {
+      doc = Document.current();
+      result = jshint.JSHINT(doc.text, config);
       var data = jshint.JSHINT.data();
       var errors = data.errors;
+  
       
-      if (typeof window === 'undefined') {
+      if (errors !== undefined && errors.length > 0) {
+        window.title = errors.length + ' errors in ' + Document.current().filename();
+        
+        window.applyFunction(function(data) {
+          
+            var errLi,
+                errFragment = document.createDocumentFragment(),
+                errList = document.getElementById('errors');
+            
+            // clear exising content first
+            errList.innerHTML = '';
+            
+            // Send a message to chocolat whenever the line number link is clicked.
+            errList.addEventListener('click', function (e) {
+              if (e.target && e.target.nodeName == 'A') {
+                chocolat.sendMessage('goToLine', [e.target.dataset.line]);
+              }
+            });
+            
+            data.errors.forEach(function (err) {
+              errLi = document.createElement('li');
+              errLi.innerHTML = '<a href="#" class="line-num" title="' + err.evidence + '" data-line="' + err.line + '">line ' + err.line + '</a> <span class="reason">' + err.reason + '</span>';
+              errFragment.appendChild(errLi);
+            });
+            
+            errList.appendChild(errFragment);
+          
+        }, [data]);
+        
+      }
+      else {
+        window.title = '0 errors in ' + doc.filename();
+        
+        window.applyFunction(function() {
+          
+          var noErrLi,
+              noErrFragment = document.createDocumentFragment(),
+              noErrList = document.getElementById('errors');
+          
+          noErrList.innerHTML = '';
+          
+          noErrLi = document.createElement('li');
+          noErrLi.classList.add('no-errors');
+          noErrLi.textContent = 'No errors.';
+          noErrFragment.appendChild(noErrLi);
+          noErrList.appendChild(noErrFragment);
+        }, []);
+        
+        
+      }
+    };
+    
+    
+    var showWindow = function(data) {
+      
+      if (window === undefined) {
         window = new Window();
         window.htmlPath = 'index.html';
-        window.buttons = ["OK"];
-        window.onButtonClick = function() { window.close(); }
+        window.buttons = ['Close', 'Refresh'];
         window.size = {width: 250, height: 300};
         
-        window.onMessage = function (name, arguments) {
+        window.onLoad = function() {
+          refreshWindow();
+        };
+        
+        // Unbind window when closing:
+        window.onUnload = function() {
+          window = undefined;
+        };
+        
+        window.onButtonClick = function(button) {
+          
+          if (button === 'Refresh') {
+            refreshWindow();
+          }
+          else if (button === 'Close') {
+            window.close();
+          }
+          
+        };
+        
+        window.onMessage = function (name, args) {
           if (name === 'goToLine') {
-            var lineNum = arguments[0];
+            var lineNum = args[0];
             
             Recipe.run(function (recipe) {
               // Line number is 0 indexed in chocolat.
@@ -41,13 +116,46 @@ Hooks.addMenuItem("Actions/JavaScript/JSHint document", "cmd-ctrl-h", function (
             });
           }
         };
+        
+        window.run();
+      }
+      else {
+        refreshWindow();
+        window.show();
       }
       
-      window.title = buildTitle(doc.filename(), errors.length);
-      window.run();
-      window.applyFunction('hinted', [data]);
-      
-    } else {
-      Alert.show("No errors", "Awesome work!", ["OK"]);
+    };
+    
+    // check scope
+    if (scope === 'js.source') {
+      if (!result) {
+        showWindow();
+      }
+      else {
+        if (window !== undefined && !(window.isKeyWindow())) {
+          window.close();
+        }
+        Alert.show('No errors', 'Awesome work!', ['OK']);
+      }
     }
+    else {
+      var filename;
+      if (doc.filename()) {
+        filename = doc.filename();
+      } else {
+        filename = 'Document';
+      }
+      
+      Alert.show('JSHint Error:', filename + ' does not appear to be Javascript.');
+    }
+    
+  }
+  
+  
+}
+
+
+
+Hooks.addMenuItem('Actions/JavaScript/JSHint document', 'cmd-ctrl-h', function() {
+  run();
 });


### PR DESCRIPTION
This Pull Request does the following:

• Window will re-open after it has been closed (even if it was closed using the red X button).

• Window will refresh on `cmd-ctrl-h` if it is already open.

• Window now has 'Refresh' button.

• If current document changed, the Window will refresh to reflect the JSHint results from the new current document.

• Mixin is now scoped to JS documents, if user runs mixin against a non-javascript document there'll be an alert (instead of an empty window with a meaningless number of errors in the title).

• If the window does not have focus while user runs mixin using `cmd-ctrl-h` to zero errors result, the No-Errors alert will be shown and the window closed.

• Will fail silently if there is no open document.
